### PR TITLE
Distinct qualified keywords get turned into distinct node IDs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]]
   :profiles
   {:dev {:dependencies [[org.clojure/clojurescript "1.9.908"]
                         [com.cemerick/piggieback "0.2.2"]]

--- a/src/dorothy/core.cljc
+++ b/src/dorothy/core.cljc
@@ -400,13 +400,14 @@
 (defn ^:private to-ast [v]
   (cond
     (is-ast? v)  v
-    (keyword? v) (parse-node-id (name v))
-    (string?  v) (parse-node-id v)
-    (number?  v) (parse-node-id (str v))
-    (gen-id?  v) (node-id v)
-    (map? v)     (graph-attrs v)
-    (vector? v)  (vector-to-ast v)
-    :else        (error "Don't know what to do with %s" v)))
+    (qualified-keyword? v) (parse-node-id (str (namespace v) "/" (name v)))
+    (keyword? v)           (parse-node-id (name v) )
+    (string?  v)           (parse-node-id v)
+    (number?  v)           (parse-node-id (str v))
+    (gen-id?  v)           (node-id v)
+    (map? v)               (graph-attrs v)
+    (vector? v)            (vector-to-ast v)
+    :else                  (error "Don't know what to do with %s" v)))
 
 (defn ^:private desugar-graph-options
   "Turn first arg of (graph) into something usable"

--- a/test/dorothy/test/core.cljc
+++ b/test/dorothy/test/core.cljc
@@ -104,3 +104,16 @@
            (->> result
                 :statements
                 (map #(select-keys % [:type :id])))))))
+
+(deftest test-to-ast
+  (testing "uses name of an un-qualified keyword"
+    (is (= {:type ::d/node-id :id "foo" :port nil :compass-pt nil}
+           (-> (d/graph [:foo])
+               :statements
+               first))))
+
+  (testing "uses namespace and name of an un-qualified keyword"
+    (is (= {:type ::d/node-id :id "foo/bar" :port nil :compass-pt nil}
+           (-> (d/graph [:foo/bar])
+               :statements
+               first)))))


### PR DESCRIPTION
We ran into trouble when using qualified keywords as nodes. In some
cases, only the namespace distinguished the keywords from each
other (e.g. :foo/bar and :baz/bar). Dorothy was generating the same
node ID for each such keyword.

This patch generates a node ID of the form "foo/bar" for qualified
keywords while continuing to use the name for non-qualified keywords.

I bumped the Clojure version to 1.9.0 so I could use the new
`qualified-keyword?` function, but if that's a problem, I'm happy to
go back down to 1.8.0 and implement it here.

Co-authored-by: Mike Pendergrass <mdpendergrass@gmail.com>
Co-authored-by: Devin Walters <devinw@gmail.com>